### PR TITLE
IE touch device fix

### DIFF
--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -62,6 +62,7 @@ $ps-bar-hover: #999;
 }
 
 .ps-container {
+  -ms-touch-action: none;
   overflow: hidden !important;
 
   &.ps-active-x > .ps-scrollbar-x-rail,


### PR DESCRIPTION
Add vendor specific css for IE to handle let javascript handle touch events instead of letting css attempt to handle them. Without this CSS property IE touch devices do not work.